### PR TITLE
Ensure right RabbitMQ client library is loaded on OSX/Mono

### DIFF
--- a/References.fsx
+++ b/References.fsx
@@ -1,12 +1,14 @@
-﻿#I @".\packages\RabbitMQ.Client.3.6.2\lib\net45"
-#I @".\packages\Newtonsoft.Json.7.0.1\lib\net45"
-#I @".\packages\Akka.1.0.8\lib\net45"
-#I @".\packages\Akka.FSharp.1.0.8\lib\net45"
-#I @".\packages\FsPickler.1.2.21\lib\net45"
-#I @".\packages\System.Collections.Immutable.1.1.36\lib\portable-net45+win8+wp8+wpa81" 
+﻿#I @"./packages/Newtonsoft.Json.7.0.1/lib/net45"
+#I @"./packages/Akka.1.0.8/lib/net45"
+#I @"./packages/Akka.FSharp.1.0.8/lib/net45"
+#I @"./packages/FsPickler.1.2.21/lib/net45"
+#I @"./packages/System.Collections.Immutable.1.1.36/lib/portable-net45+win8+wp8+wpa81" 
 
+// Mono has a build in version of RabbitMQ that takes
+// precedance unless with fully quality the path to the client
+// library that we really want to load
+#r "./packages/RabbitMQ.Client.3.6.2/lib/net45/RabbitMQ.Client.dll"
 #r "System.Collections.Immutable.dll"
-#r "RabbitMQ.Client.dll"
 #r "Akka.dll"
 #r "Akka.FSharp.dll"
 


### PR DESCRIPTION
Mono has a different way of handling #r and #i for the F# interactive. This commit is needed for loading the right RabbitMQ client library on OSX/Mono.
